### PR TITLE
Ignoring errors on subscription-manager remove --all; Using FQCN for dict2items; Adding noqa for ignore_errors

### DIFF
--- a/tasks/register.yml
+++ b/tasks/register.yml
@@ -3,9 +3,12 @@
   become: true
   block:
 
-    - name: 'register | Unregister the system'
+    # it makes no sense to account for specific errors, as subscription-manager
+    # has at times unpredictable errors
+    - name: 'register | Unregister the system'  # noqa: ignore-errors
       ansible.builtin.command:
         cmd: 'subscription-manager remove --all'
+      ignore_errors: true
       changed_when: true
 
     - name: 'register | Ensure subscription-manager removes all local data'
@@ -23,7 +26,7 @@
         name: >-
           {{
             ansible_facts.packages |
-            dict2items |
+            ansible.builtin.dict2items |
             selectattr('key', 'match', _rts_katello_ca_consumer_regexp) |
             map(attribute='key') |
             list
@@ -31,7 +34,7 @@
         state: 'absent'
       when: >
         ansible_facts.packages |
-        dict2items |
+        ansible.builtin.dict2items |
         selectattr('key', 'match', _rts_katello_ca_consumer_regexp) |
         map(attribute='key') |
         list | length > 0


### PR DESCRIPTION
Ignoring errors on subscription-manager remove --all; Using FQCN for dict2items; Adding noqa for ignore_errors